### PR TITLE
SEND_PARAMSで送信フィールドをフィルタする機能を追加

### DIFF
--- a/README-JP.md
+++ b/README-JP.md
@@ -62,6 +62,7 @@ OpenCode を再起動してください。
 - `DISCORD_WEBHOOK_COMPLETE_MENTION`: `session.idle` / `session.error` の通知本文に付けるメンション（`@everyone` または `@here` のみ許容。Forum webhook の仕様上、ping は常に発生しない）
 - `DISCORD_WEBHOOK_PERMISSION_MENTION`: `permission.updated` の通知本文に付けるメンション（`DISCORD_WEBHOOK_COMPLETE_MENTION` へのフォールバックなし。`@everyone` または `@here` のみ許容。Forum webhook の仕様上、ping は常に発生しない）
 - `DISCORD_WEBHOOK_EXCLUDE_INPUT_CONTEXT`: `1` のとき input context（`<file>` から始まる user `text` part）を通知しない（デフォルト: `1` / `0` で無効化）
+- `SEND_PARAMS`: embed の fields として送るキーをカンマ区切りで指定。指定可能キー: `sessionID`, `permissionID`, `type`, `pattern`, `messageID`, `callID`, `partID`, `role`, `directory`, `projectID`。未設定・空文字・空要素のみの場合は全て選択。`session.created` は `SEND_PARAMS` に関わらず `sessionID`, `projectID`, `directory` を必ず含みます。
 
 ## 仕様メモ
 
@@ -83,6 +84,7 @@ OpenCode を再起動してください。
   - `text`: user は即時通知。assistant は `part.time.end` がある確定時のみ通知（ストリーミング途中更新は通知しない）
   - `tool`: 通知しない
   - `reasoning`: 通知しない（内部思考が含まれる可能性があるため）
+- `SEND_PARAMS` の制御対象は embed の fields のみです（title/description/content/timestamp などは対象外）。また `share` は fields としては送りません（Session started の embed URL には `shareUrl` を使います）。
 
 ## 動作確認（手動）
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Optional:
 - `DISCORD_WEBHOOK_COMPLETE_MENTION`: mention to put in `session.idle` / `session.error` messages (only `@everyone` or `@here` supported; Forum webhooks may not actually ping due to Discord behavior)
 - `DISCORD_WEBHOOK_PERMISSION_MENTION`: mention to put in `permission.updated` messages (no fallback to `DISCORD_WEBHOOK_COMPLETE_MENTION`; only `@everyone` or `@here` supported; Forum webhooks may not actually ping due to Discord behavior)
 - `DISCORD_WEBHOOK_EXCLUDE_INPUT_CONTEXT`: when set to `1`, exclude "input context" (user `text` parts that start with `<file>`) from notifications (default: `1`; set to `0` to disable)
+- `SEND_PARAMS`: comma-separated list of keys to include as embed fields. Allowed keys: `sessionID`, `permissionID`, `type`, `pattern`, `messageID`, `callID`, `partID`, `role`, `directory`, `projectID`. If unset, empty, or containing only empty elements, all keys are selected. `session.created` always includes `sessionID`, `projectID`, `directory` regardless.
 
 ## Notes / behavior
 
@@ -85,6 +86,7 @@ Optional:
   - `text`: user is posted immediately; assistant is posted only when finalized (when `part.time.end` exists)
   - `tool`: not posted
   - `reasoning`: not posted (to avoid exposing internal thoughts)
+- `SEND_PARAMS` controls embed fields only (it does not affect title/description/content/timestamp). `share` is not an embed field (but Session started uses `shareUrl` as the embed URL).
 
 ## Manual test
 


### PR DESCRIPTION
## 🔗 Related Issue

- Closes #20

---

## 📘 Summary

<!-- Briefly describe what this PR does in 1–3 lines -->

- Discord 通知で埋め込みフィールドとして送信するキーを環境変数 `SEND_PARAMS` で指定できるようにします。既存のデフォルトキーは保持され、カンマ区切りで上書き可能です。

---

## 🛠️ Changes

<!-- List concrete changes made -->

- `src/index.ts`: `parseSendParams` 関数の追加、`SEND_PARAMS` 環境変数の読み取りとフィルタ処理の適用を追加
- `README.md`: `SEND_PARAMS` の欄を追記
- `README-JP.md`: `SEND_PARAMS` の利用方法（日本語）を追記

## 🎯 Background / Purpose

<!-- Explain why this change was necessary. Additional context from the issue is OK -->

- 通知に含めるメタ情報（sessionID 等）を柔軟に制御する要望があり、環境変数で許可するキーを指定できるようにする必要がありました（Issue #20 に関連）。

---

## ✅ Verification

<!-- Steps taken to verify, attach screenshots if applicable -->

- [x] Build succeeds
- [ ] Functionality verified

---

## 🧩 Impact Scope

<!-- Example: UI / API / DB / logic / dependent packages -->

- ロジック: Discord 通知のフィールド選択ロジックに影響
- ドキュメント: `README.md` / `README-JP.md` を更新

## 📎 Notes

<!-- Any special notes or considerations -->

- デフォルトで既存のキーセットが使われるため、既存挙動は破壊しません。`SEND_PARAMS` が空または未設定の場合、従来どおり全てのデフォルトキーを送信します。
