### PR TITLE
テキスト通知のEmbedタイトルを改善（User says / Agent says）

### DIFF
--- a/README-JP.md
+++ b/README-JP.md
@@ -82,6 +82,7 @@ OpenCode を再起動してください。
 - `message.updated` は通知しません（role 判定用に追跡。role 未確定で保留した `text` part を後から通知することがあります）。
 - `message.part.updated` は以下の方針です。
   - `text`: user は即時通知。assistant は `part.time.end` がある確定時のみ通知（ストリーミング途中更新は通知しない）
+    - embed タイトルは `User says` / `Agent says` です
   - `tool`: 通知しない
   - `reasoning`: 通知しない（内部思考が含まれる可能性があるため）
 - `SEND_PARAMS` の制御対象は embed の fields のみです（title/description/content/timestamp などは対象外）。また `share` は fields としては送りません（Session started の embed URL には `shareUrl` を使います）。

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Optional:
 - `message.updated` is not posted (tracked for role inference; may post a previously-held text part later).
 - `message.part.updated` policy:
   - `text`: user is posted immediately; assistant is posted only when finalized (when `part.time.end` exists)
+    - Embed titles are `User says` / `Agent says`
   - `tool`: not posted
   - `reasoning`: not posted (to avoid exposing internal thoughts)
 - `SEND_PARAMS` controls embed fields only (it does not affect title/description/content/timestamp). `share` is not an embed field (but Session started uses `shareUrl` as the embed URL).

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,6 +115,10 @@ function filterSendFields(
   })
 }
 
+function getTextPartEmbedTitle(role: 'user' | 'assistant'): string {
+  return role === 'user' ? 'User says' : 'Agent says'
+}
+
 function withForcedSendParams(
   base: Set<SendParamKey>,
   forced: SendParamKey[],
@@ -738,10 +742,7 @@ const plugin: Plugin = async () => {
                   }
 
                   const embed: DiscordEmbed = {
-                    title:
-                      role === 'user'
-                        ? 'Message part updated: text (user)'
-                        : 'Message part updated: text (assistant)',
+                    title: getTextPartEmbedTitle(role),
                     color: COLORS.info,
                     fields: buildFields(
                       filterSendFields(
@@ -817,10 +818,7 @@ const plugin: Plugin = async () => {
               }
 
               const embed: DiscordEmbed = {
-                title:
-                  role === 'user'
-                    ? 'Message part updated: text (user)'
-                    : 'Message part updated: text (assistant)',
+                title: getTextPartEmbedTitle(role),
                 color: COLORS.info,
                 fields: buildFields(
                   filterSendFields(


### PR DESCRIPTION
## 🔗 Related Issue

- Closes #19

---

## 📘 Summary

テキストパートの Discord embed タイトルを可読性の高い表記に変更します（`Message part updated: text (user|assistant)` → `User says` / `Agent says`）。ドキュメントに該当表記の追記を行いました。

---

## 🛠️ Changes

- `src/index.ts`:
  - 追加: `getTextPartEmbedTitle(role)` ヘルパーを導入
  - 変更: text 通知の embed `title` を直接の文言からヘルパーに差し替え (`User says` / `Agent says` を返す)
- `README.md`, `README-JP.md`:
  - `message.part.updated` における embed タイトルが `User says` / `Agent says` である旨を1行追記

## 🎯 Background / Purpose

Discord 上で通知を一覧するときに「誰の発言か」が一目で分かる方が UX が向上するため。既存の `Message part updated: text (user|assistant)` は機械的で視認性が低く、スレッドを俯瞰で確認する運用で使いにくいという課題がありました（Issue #19）。

---

## ✅ Verification

- [x] Build succeeds
- [ ] Functionality verified

（ローカルで `npm run build` による dist 生成を確認済み）

---

## 🧩 Impact Scope

- ロジック: なし（内部の `role` 値や通知タイミングは不変）
- UI（Discord 表示）: はい（embed のタイトル表示が変更されます）
- ドキュメント: はい（README に表記追記）
- 破壊的変更: なし

## 📎 Notes

- 変更はタイトル表示のみであり、通知の条件（user は即時、assistant は `part.time.end` 確定時）や embed の fields（`role: user|assistant`）はそのまま維持しています。
- 影響を考慮して、サンプル画像（`assets/image/sample-forum-ch.png`）の差し替えが必要な場合は別PRで対応してください。
