### PR TITLE
Discord webhook のエラー通知を TUI トーストで表示（429 リトライ改善）

### DIFF
--- a/README-JP.md
+++ b/README-JP.md
@@ -62,11 +62,14 @@ OpenCode を再起動してください。
 - `DISCORD_WEBHOOK_COMPLETE_MENTION`: `session.idle` / `session.error` の通知本文に付けるメンション（`@everyone` または `@here` のみ許容。Forum webhook の仕様上、ping は常に発生しない）
 - `DISCORD_WEBHOOK_PERMISSION_MENTION`: `permission.updated` の通知本文に付けるメンション（`DISCORD_WEBHOOK_COMPLETE_MENTION` へのフォールバックなし。`@everyone` または `@here` のみ許容。Forum webhook の仕様上、ping は常に発生しない）
 - `DISCORD_WEBHOOK_EXCLUDE_INPUT_CONTEXT`: `1` のとき input context（`<file>` から始まる user `text` part）を通知しない（デフォルト: `1` / `0` で無効化）
+- `DISCORD_WEBHOOK_SHOW_ERROR_ALERT`: `1` のとき Discord webhook の送信が失敗した場合に OpenCode TUI のトーストを表示します（429 含む）（デフォルト: `1` / `0` で無効化）
 - `SEND_PARAMS`: embed の fields として送るキーをカンマ区切りで指定。指定可能キー: `sessionID`, `permissionID`, `type`, `pattern`, `messageID`, `callID`, `partID`, `role`, `directory`, `projectID`。未設定・空文字・空要素のみの場合は全て選択。`session.created` は `SEND_PARAMS` に関わらず `sessionID`, `projectID`, `directory` を必ず含みます。
 
 ## 仕様メモ
 
-- `DISCORD_WEBHOOK_URL` 未設定の場合は no-op（ログに警告のみ）です。
+- `DISCORD_WEBHOOK_URL` 未設定の場合は no-op です。
+- Discord webhook の送信が失敗した場合、OpenCode TUI のトーストを表示することがあります（`DISCORD_WEBHOOK_SHOW_ERROR_ALERT` で制御）。
+- HTTP 429 の場合は `retry_after` があればそれを優先し、なければ 10 秒程度待って 1 回だけリトライし、それでも失敗した場合は warning トーストを表示します。
 - Forum スレッド作成時は `?wait=true` を付け、レスポンスの `channel_id` を thread ID として利用します。
 - スレッド名（`thread_name`）は以下の優先度です（最大100文字）。
   1. 最初の user `text`

--- a/README.md
+++ b/README.md
@@ -64,11 +64,14 @@ Optional:
 - `DISCORD_WEBHOOK_COMPLETE_MENTION`: mention to put in `session.idle` / `session.error` messages (only `@everyone` or `@here` supported; Forum webhooks may not actually ping due to Discord behavior)
 - `DISCORD_WEBHOOK_PERMISSION_MENTION`: mention to put in `permission.updated` messages (no fallback to `DISCORD_WEBHOOK_COMPLETE_MENTION`; only `@everyone` or `@here` supported; Forum webhooks may not actually ping due to Discord behavior)
 - `DISCORD_WEBHOOK_EXCLUDE_INPUT_CONTEXT`: when set to `1`, exclude "input context" (user `text` parts that start with `<file>`) from notifications (default: `1`; set to `0` to disable)
+- `DISCORD_WEBHOOK_SHOW_ERROR_ALERT`: when set to `1`, show an OpenCode TUI toast when Discord webhook requests fail (includes 429). (default: `1`; set to `0` to disable)
 - `SEND_PARAMS`: comma-separated list of keys to include as embed fields. Allowed keys: `sessionID`, `permissionID`, `type`, `pattern`, `messageID`, `callID`, `partID`, `role`, `directory`, `projectID`. If unset, empty, or containing only empty elements, all keys are selected. `session.created` always includes `sessionID`, `projectID`, `directory` regardless.
 
 ## Notes / behavior
 
-- If `DISCORD_WEBHOOK_URL` is not set, it becomes a no-op (logs a warning only).
+- If `DISCORD_WEBHOOK_URL` is not set, it becomes a no-op.
+- If a webhook request fails, it may show an OpenCode TUI toast (controlled by `DISCORD_WEBHOOK_SHOW_ERROR_ALERT`).
+- On HTTP 429, it waits `retry_after` seconds if provided (otherwise ~10s) and retries once; if it still fails, it shows a warning toast.
 - For Forum thread creation, it appends `?wait=true` and uses `channel_id` in the response as the thread ID.
 - `thread_name` priority order (max 100 chars):
   1. first user `text`


### PR DESCRIPTION
## 🔗 Related Issue

- Closes #14

---

## 📘 Summary

OpenCode から Discord Webhook 送信が失敗した際に、OpenCode TUI のトーストでユーザーへ通知する機能を追加します。HTTP 429（rate limit）ではレスポンスの `retry_after` を優先して待機し、なければ 10 秒待機して 1 回だけリトライします。

---

## 🛠️ Changes

- `src/index.ts` に以下を実装・修正
  - HTTP 429 時の待機ロジックを `retry_after`（body または `Retry-After` ヘッダ）優先に変更し、存在しない場合は既存の 10 秒フォールバックで 1 回だけリトライするようにした
  - Discord Webhook の失敗時に OpenCode TUI のトーストを表示する仕組みを追加（`client.tui.showToast` を利用）
  - `DISCORD_WEBHOOK_SHOW_ERROR_ALERT` 環境変数でトースト表示の有効/無効を制御するようにした
  - 連続でトーストが出ないようにキー単位でクールダウン（約30秒）を導入
  - 失敗時のキュー保持（`flushPending` 系）を改良し、送信済みの分だけ削除するようにして通知ロストを防止
  - `console.*` 出力を完全に除去（サイレント化）
- ドキュメント更新
  - `README.md` と `README-JP.md` の該当箇所に `DISCORD_WEBHOOK_SHOW_ERROR_ALERT` と 429 の挙動（`retry_after` 優先）を追記
- テスト計画は `src/index.ts` 内にコメントとして残してある（別ブランチで実装予定）

## 🎯 Background / Purpose

Issue #14 の要望に基づき、Discord 側のレート制限やその他エラー時にユーザーへ明示的に通知する必要がありました。特に 429 の待機時間は Discord が返す `retry_after` を尊重することで、無駄な待機や誤ったリトライを避けることが目的です。

---

## ✅ Verification

- [x] Build succeeds
- [ ] Functionality verified

※ ローカルで `npm run format && npm run build` を実行してビルドは成功しています。動作確認（TUI 表示の実機確認等）は必要に応じてお願いします。

---

## 🧩 Impact Scope

- UI: OpenCode TUI のトースト表示を追加
- Logic: Discord Webhook のエラーハンドリング（429 リトライ、キュー保持、エラートースト）を変更
- Docs: `README.md` / `README-JP.md` を更新

## 📎 Notes

- テストはこの PR では追加していません。`src/index.ts` 内にテスト計画コメントを残しているため、別ブランチ/別セッションでモックを用いた単体テストを追加してください。
- ブランチ名が `feature/14` のため、Issue 番号は `#14` を自動クローズ対象として設定しています。