### PR TITLE
DISCORD_WEBHOOK_URL 未設定時に英語で警告を表示し、通知キューを溜めないようにする (#28)

### DIFF
--- a/README-JP.md
+++ b/README-JP.md
@@ -63,7 +63,7 @@ OpenCode を再起動してください。
 - `DISCORD_WEBHOOK_PERMISSION_MENTION`: `permission.updated` の通知本文に付けるメンション（`DISCORD_WEBHOOK_COMPLETE_MENTION` へのフォールバックなし。`@everyone` または `@here` のみ許容。Forum webhook の仕様上、ping は常に発生しない）
 - `DISCORD_WEBHOOK_EXCLUDE_INPUT_CONTEXT`: `1` のとき input context（`<file>` から始まる user `text` part）を通知しない（デフォルト: `1` / `0` で無効化）
 - `DISCORD_WEBHOOK_SHOW_ERROR_ALERT`: `1` のとき Discord webhook の送信が失敗した場合に OpenCode TUI のトーストを表示します（429 含む）（デフォルト: `1` / `0` で無効化）
-- `SEND_PARAMS`: embed の fields として送るキーをカンマ区切りで指定。指定可能キー: `sessionID`, `permissionID`, `type`, `pattern`, `messageID`, `callID`, `partID`, `role`, `directory`, `projectID`。未設定・空文字・空要素のみの場合は全て選択。`session.created` は `SEND_PARAMS` に関わらず `sessionID`, `projectID`, `directory` を必ず含みます。
+- `DISCORD_SEND_PARAMS`: embed の fields として送るキーをカンマ区切りで指定。指定可能キー: `sessionID`, `permissionID`, `type`, `pattern`, `messageID`, `callID`, `partID`, `role`, `directory`, `projectID`。未設定・空文字・空要素のみの場合は全て選択。`session.created` は `DISCORD_SEND_PARAMS` に関わらず `sessionID`, `projectID`, `directory` を必ず含みます。
 
 ## 仕様メモ
 
@@ -88,7 +88,7 @@ OpenCode を再起動してください。
     - embed タイトルは `User says` / `Agent says` です
   - `tool`: 通知しない
   - `reasoning`: 通知しない（内部思考が含まれる可能性があるため）
-- `SEND_PARAMS` の制御対象は embed の fields のみです（title/description/content/timestamp などは対象外）。また `share` は fields としては送りません（Session started の embed URL には `shareUrl` を使います）。
+- `DISCORD_SEND_PARAMS` の制御対象は embed の fields のみです（title/description/content/timestamp などは対象外）。また `share` は fields としては送りません（Session started の embed URL には `shareUrl` を使います）。
 
 ## 動作確認（手動）
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Optional:
 - `DISCORD_WEBHOOK_PERMISSION_MENTION`: mention to put in `permission.updated` messages (no fallback to `DISCORD_WEBHOOK_COMPLETE_MENTION`; only `@everyone` or `@here` supported; Forum webhooks may not actually ping due to Discord behavior)
 - `DISCORD_WEBHOOK_EXCLUDE_INPUT_CONTEXT`: when set to `1`, exclude "input context" (user `text` parts that start with `<file>`) from notifications (default: `1`; set to `0` to disable)
 - `DISCORD_WEBHOOK_SHOW_ERROR_ALERT`: when set to `1`, show an OpenCode TUI toast when Discord webhook requests fail (includes 429). (default: `1`; set to `0` to disable)
-- `SEND_PARAMS`: comma-separated list of keys to include as embed fields. Allowed keys: `sessionID`, `permissionID`, `type`, `pattern`, `messageID`, `callID`, `partID`, `role`, `directory`, `projectID`. If unset, empty, or containing only empty elements, all keys are selected. `session.created` always includes `sessionID`, `projectID`, `directory` regardless.
+- `DISCORD_SEND_PARAMS`: comma-separated list of keys to include as embed fields. Allowed keys: `sessionID`, `permissionID`, `type`, `pattern`, `messageID`, `callID`, `partID`, `role`, `directory`, `projectID`. If unset, empty, or containing only empty elements, all keys are selected. `session.created` always includes `sessionID`, `projectID`, `directory` regardless.
 
 ## Notes / behavior
 
@@ -90,7 +90,7 @@ Optional:
     - Embed titles are `User says` / `Agent says`
   - `tool`: not posted
   - `reasoning`: not posted (to avoid exposing internal thoughts)
-- `SEND_PARAMS` controls embed fields only (it does not affect title/description/content/timestamp). `share` is not an embed field (but Session started uses `shareUrl` as the embed URL).
+- `DISCORD_SEND_PARAMS` controls embed fields only (it does not affect title/description/content/timestamp). `share` is not an embed field (but Session started uses `shareUrl` as the embed URL).
 
 ## Manual test
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-discord-notify",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A plugin that posts OpenCode events to a Discord webhook.",
   "license": "MIT",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -438,7 +438,7 @@ const plugin: Plugin = async ({ client }) => {
   const waitOnRateLimitMs = 10_000
   const toastCooldownMs = 30_000
 
-  const sendParams = parseSendParams(getEnv('SEND_PARAMS'))
+  const sendParams = parseSendParams(getEnv('DISCORD_SEND_PARAMS'))
 
   const lastAlertAtByKey = new Map<string, number>()
 
@@ -465,6 +465,22 @@ const plugin: Plugin = async ({ client }) => {
     lastAlertAtByKey.set(key, now)
     await showToast({ title, message, variant })
   }
+
+  const MISSING_URL_KEY = 'discord_webhook_missing_url'
+  async function showMissingUrlToastOnce() {
+    const now = Date.now()
+    const last = lastAlertAtByKey.get(MISSING_URL_KEY)
+    if (last !== undefined && now - last < toastCooldownMs) return
+    lastAlertAtByKey.set(MISSING_URL_KEY, now)
+    await showToast({
+      title: 'Discord webhook not configured',
+      message:
+        'DISCORD_WEBHOOK_URL is not set. Please configure it to enable Discord notifications.',
+      variant: 'warning',
+    })
+  }
+
+  if (!webhookUrl) void showMissingUrlToastOnce()
 
   const postDeps: PostDiscordWebhookDeps = {
     showErrorAlert,
@@ -555,6 +571,12 @@ const plugin: Plugin = async ({ client }) => {
   }
 
   function enqueueToThread(sessionID: string, body: DiscordExecuteWebhookBody) {
+    if (!webhookUrl) {
+      // show a one-time warning to the user (non-blocking) and do not queue
+      void showMissingUrlToastOnce()
+      return
+    }
+
     const queue = pendingPostsBySession.get(sessionID) ?? []
     queue.push(body)
     pendingPostsBySession.set(sessionID, queue)


### PR DESCRIPTION
* v0.3.1

* fix: warn when DISCORD_WEBHOOK_URL missing, avoid queueing (close #15)

* fix(config): 環境変数名を DISCORD_SEND_PARAMS に変更

BREAKING CHANGE: `SEND_PARAMS` を廃止しました。既存の利用者は `DISCORD_SEND_PARAMS` に移行してください。