### PR TITLE
fix(github): mainブランチへのowner直接push禁止設定に変更

### DIFF
--- a/.github/rulesets/main-branch-protection-with-conventional-commits.json
+++ b/.github/rulesets/main-branch-protection-with-conventional-commits.json
@@ -6,7 +6,7 @@
     {
       "actor_id": 5,
       "actor_type": "RepositoryRole",
-      "bypass_mode": "always"
+      "bypass_mode": "pull_request"
     }
   ],
   "conditions": {


### PR DESCRIPTION
## Summary

mainブランチ保護ルールの`bypass_mode`を`"always"`から`"pull_request"`に変更し、ownerであってもmainブランチへの直接pushを禁止する設定に変更しました。

### 変更内容
- `.github/rulesets/main-branch-protection-with-conventional-commits.json`の`bypass_mode`を変更

### 変更後の動作
- ✅ mainブランチへの直接push：全員NG（ownerも含む）
- ✅ PR必須：全員に適用
- ✅ PRの承認：ownerはバイパス可能（承認なしでmerge可能）、それ以外は1承認必要

## Test plan
- [ ] ルールセット設定ファイルの変更内容を確認
- [ ] GitHub上で実際にルールセットが適用されていることを確認
- [ ] owner権限でmainブランチへの直接pushが拒否されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)