### PR TITLE
docs: READMEから不要なmarkdownlintコメントを削除

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "markdownlint.config": {
+    "MD033": false
+  }
+}

--- a/README-JP.md
+++ b/README-JP.md
@@ -10,11 +10,9 @@
 
 [English](README.md) | 日本語
 
-<!-- markdownlint-disable -->
 <p align="center">
   <img src="assets/image/sample-forum-ch.png" width="700" alt="Discord Forum channel example" />
 </p>
-<!-- markdownlint-enable -->
 
 OpenCode のイベントを Discord Webhook に通知するプラグインです。
 Discord の Forum チャンネル webhook を前提に、セッション開始時（または最初の通知タイミング）にスレッド（投稿）を作成して、その後の更新を同スレッドに流します。

--- a/README.md
+++ b/README.md
@@ -10,11 +10,9 @@
 
 English | [日本語](README-JP.md)
 
-<!-- markdownlint-disable -->
 <p align="center">
   <img src="assets/image/sample-forum-ch.png" width="700" alt="Discord Forum channel example" />
 </p>
-<!-- markdownlint-enable -->
 
 A plugin that posts OpenCode events to a Discord webhook.
 


### PR DESCRIPTION
## Summary
- README-JP.md と README.md から不要な `<!-- markdownlint-disable -->` / `<!-- markdownlint-enable -->` コメントを削除
- `.vscode/settings.json` に markdownlint 設定（MD033: false）を追加してHTML許可

これにより、READMEファイル内でHTMLタグ（画像表示用の `<p align="center">` など）を使用できるようにしつつ、ファイル内のコメントを削除してクリーンな状態にしました。

## Test plan
- [x] README-JP.md と README.md のレンダリング確認
- [x] markdownlint の警告が出ないことを確認
- [x] .vscode/settings.json が正しく機能することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)