### PR TITLE
fix(session.idle): DISCORD_SEND_PARAMSが空の時にsessionIDが表示される問題を修正

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -875,7 +875,7 @@ const plugin: Plugin = async ({ client }) => {
               fields: buildFields(
                 filterSendFields(
                   [['sessionID', sessionID]],
-                  withForcedSendParams(sendParams, ['sessionID']),
+                  sendParams,
                 ),
               ),
             }


### PR DESCRIPTION
## 概要

DISCORD_SEND_PARAMSを空にしていても、`session.idle`イベント時にsessionIDが表示される問題を修正しました。

## 問題

`session.idle`イベント処理で`withForcedSendParams(sendParams, ['sessionID'])`を使用していたため、DISCORD_SEND_PARAMSが空でも強制的にsessionIDがfieldsに含まれていました。

## 仕様

README-JP.mdの仕様では：
- DISCORD_SEND_PARAMSが未設定・空文字の場合：「全て無効化（何も送信しない）」
- `session.created`のみ例外として`sessionID`, `projectID`, `directory`を必ず含む

## 修正内容

`src/index.ts:878` の`session.idle`イベント処理から`withForcedSendParams()`を削除し、`sendParams`のみを使用するように修正しました。

```diff
  fields: buildFields(
    filterSendFields(
      [['sessionID', sessionID]],
-     withForcedSendParams(sendParams, ['sessionID']),
+     sendParams,
    ),
  ),
```

## テスト結果

- ✅ 全36件の既存テストが成功
- ✅ 既存機能への影響なし

## チェックリスト

- [x] コードの変更が仕様に準拠している
- [x] 既存のテストがすべて通過している
- [x] コミットメッセージがConventional Commitsに準拠している

🤖 Generated with [Claude Code](https://claude.com/claude-code)