### PR TITLE
feat: @メンション時のフォールバックWebhook通知機能を追加 (#16)

### DIFF
--- a/README-JP.md
+++ b/README-JP.md
@@ -66,6 +66,7 @@ OpenCode を再起動してください。
   - **デフォルト動作**（未設定・空文字）: 全て無効化（何も送信しない）
   - **全て送信したい場合**: 全キーを列挙してください
   - **注意**: `session.created` は `DISCORD_SEND_PARAMS` に関わらず `sessionID` を必ず含みます
+- `DISCORD_WEBHOOK_FALLBACK_URL`: フォールバック先のテキストチャネル webhook URL（任意。設定すると、`@everyone` または `@here` を含むメッセージが自動的にこの webhook にも送信されます。Forum webhook ではメンションが ping しない Discord の仕様上、有用）
 
 ## 仕様メモ
 
@@ -91,6 +92,11 @@ OpenCode を再起動してください。
   - `tool`: 通知しない
   - `reasoning`: 通知しない（内部思考が含まれる可能性があるため）
 - `DISCORD_SEND_PARAMS` の制御対象は embed の fields のみです（title/description/content/timestamp などは対象外）。また `share` は fields としては送りません（Session started の embed URL には `shareUrl` を使います）。
+- `DISCORD_WEBHOOK_FALLBACK_URL` が設定されている場合:
+  - `@everyone` または `@here` を含むメッセージ（`DISCORD_WEBHOOK_COMPLETE_MENTION` または `DISCORD_WEBHOOK_PERMISSION_MENTION` 経由）は、Forum webhook（スレッド投稿）とフォールバック先のテキストチャネル webhook の両方に自動的に送信されます。
+  - これにより、Forum webhook ではメンションが ping しない Discord の仕様上、確実に通知を届けることができます。
+  - フォールバックメッセージには、`DISCORD_SEND_PARAMS` の設定に関わらず、常に `sessionID` と `thread title` フィールドが含まれます（テキストチャネルでのコンテキスト提供のため）。`thread title` は Forum のスレッド名と同じ値（最初のユーザーテキスト、または存在しない場合はセッションタイトル）です。
+  - フォールバック送信は Forum スレッドキューとは独立しており、即座に実行されます。
 
 ## 動作確認（手動）
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Optional:
   - **Default behavior** (unset/empty): all fields are disabled (nothing sent)
   - **To send all fields**: list all keys explicitly
   - **Note**: `session.created` always includes `sessionID` regardless
+- `DISCORD_WEBHOOK_FALLBACK_URL`: fallback webhook URL for text channel (optional; when set, messages containing `@everyone` or `@here` are automatically sent to this webhook as well; useful because Forum webhooks may not ping mentions due to Discord behavior)
 
 ## Notes / behavior
 
@@ -93,6 +94,11 @@ Optional:
   - `tool`: not posted
   - `reasoning`: not posted (to avoid exposing internal thoughts)
 - `DISCORD_SEND_PARAMS` controls embed fields only (it does not affect title/description/content/timestamp). `share` is not an embed field (but Session started uses `shareUrl` as the embed URL).
+- When `DISCORD_WEBHOOK_FALLBACK_URL` is set:
+  - Messages containing `@everyone` or `@here` (via `DISCORD_WEBHOOK_COMPLETE_MENTION` or `DISCORD_WEBHOOK_PERMISSION_MENTION`) are automatically sent to both the Forum webhook (as a thread post) and the fallback text channel webhook.
+  - This ensures reliable notifications while maintaining thread structure in Forums, since Forum webhooks may not ping mentions due to Discord behavior.
+  - Fallback messages always include `sessionID` and `thread title` fields, regardless of `DISCORD_SEND_PARAMS` settings, to provide context in the text channel. The `thread title` is the same as the Forum thread name (first user text, or session title if unavailable).
+  - Fallback sending is independent of the Forum thread queue and happens immediately.
 
 ## Manual test
 


### PR DESCRIPTION
## 概要

フォーラムWebhookで@メンションが通知（ping）されないDiscordの仕様上の問題に対応するため、メンションを含むメッセージを自動的にテキストチャネルWebhookにも送信するフォールバック機能を追加しました。

Fixes #16

## 追加機能

### 環境変数
- **`DISCORD_WEBHOOK_FALLBACK_URL`**: フォールバック先のテキストチャネルWebhook URL（任意）
  - 設定すると、`@everyone`または`@here`を含むメッセージが自動的にこのWebhookにも送信されます

### フォールバック送信の動作
- **送信条件**:
  - `permission.updated`: `DISCORD_WEBHOOK_PERMISSION_MENTION`が`@everyone`/`@here`に設定されている場合
  - `session.idle`: `DISCORD_WEBHOOK_COMPLETE_MENTION`が`@everyone`/`@here`に設定されている場合
  - `session.error`: `DISCORD_WEBHOOK_COMPLETE_MENTION`が`@everyone`/`@here`に設定されている場合

- **フォールバック通知の内容**:
  - `DISCORD_SEND_PARAMS`の設定に関係なく、常に以下のfieldsを含める:
    - `sessionID`: セッションID
    - `thread title`: フォーラムのスレッドタイトルと同じ値（最初のユーザーテキスト、または存在しない場合はセッションタイトル）

### 設計のポイント
- **シンプル**: 環境変数1つ（`DISCORD_WEBHOOK_FALLBACK_URL`）でフォールバック機能を制御
- **直感的**: URLを設定するだけで自動的に動作
- **安全**: 既存動作を破壊しない（URL未設定時は既存と同じ動作）

## その他の修正

- **fix**: `session.error`イベントでメンションが正しく表示されない既存バグを修正
  - `` `$Session error` `` → `` `${mention.content}` ``

## テスト計画

### 環境変数設定例
```bash
export DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/xxx/yyy" # フォーラムチャネル
export DISCORD_WEBHOOK_FALLBACK_URL="https://discord.com/api/webhooks/aaa/bbb" # テキストチャネル
export DISCORD_WEBHOOK_COMPLETE_MENTION="@everyone"
export DISCORD_WEBHOOK_PERMISSION_MENTION="@here"
```

### 確認項目
- [x] 権限要求イベント発火 → フォーラムとテキストチャネル両方に投稿される
- [x] セッション完了 → 両方に投稿される
- [x] セッションエラー → 両方に投稿され、メンション内容が正しく表示される（既存バグ修正の確認）
- [x] `DISCORD_WEBHOOK_FALLBACK_URL`未設定 → フォールバック送信されない（既存動作）
- [x] メンション設定なし → フォールバック送信されない

<img width="980" height="1170" alt="image" src="https://github.com/user-attachments/assets/fb819fb0-6c5f-44a1-8cd1-dcd26d3bc704" />

## 変更ファイル
- `src/index.ts`: メイン実装（150行追加、10行削除）
- `README.md`: 英語版ドキュメント更新（6行追加）
- `README-JP.md`: 日本語版ドキュメント更新（6行追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)